### PR TITLE
#242 убрал ненужный overlay

### DIFF
--- a/handlers/tutorial/client/tutorialMapModal.js
+++ b/handlers/tutorial/client/tutorialMapModal.js
@@ -55,22 +55,7 @@ TutorialMapModal.prototype.remove = function() {
 TutorialMapModal.prototype.request = function(options) {
   var request = xhr(options);
 
-  request.addEventListener('loadstart', function() {
-    var onEnd = this.startRequestIndication();
-    request.addEventListener('loadend', onEnd);
-  }.bind(this));
-
   return request;
 };
-
-TutorialMapModal.prototype.startRequestIndication = function() {
-  this.showOverlay();
-  var self = this;
-
-  return function onEnd() {
-    self.hideOverlay();
-  };
-};
-
 
 module.exports = TutorialMapModal;


### PR DESCRIPTION
1. когда открывается модальный диалог (а  TutorialMapModal это миксин к Modal) уже появляется паранджа (оверлей): https://github.com/iliakan/javascript-nodejs/blob/master/styles/blocks/modal/modal.styl#L12
2. потом сразу начинается реквест и пока он не ответил накладывается метод showOverlay() который добавляет еще один слой паранджи но светлой
3. как только реквест пришел, он убирается и начинается вставка в DOM (в этом промежутке спинер выглядит нормально)

я так и не понял зачем тут показывать дополнительный оверлей, поэтому просто убрал это из прототипа в конструкторе.